### PR TITLE
Expose RootCloseWrapper in public API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export Overlay from './Overlay';
 export Portal from './Portal';
 export Position from './Position';
 export Transition from './Transition';
+export RootCloseWrapper from './RootCloseWrapper';


### PR DESCRIPTION
I want to use `RootCloseWrapper` _so bad_ I am going to temporarily maintain my own fork until https://github.com/react-bootstrap/react-overlays/issues/77 can be resolved.

There was once a PR (https://github.com/react-bootstrap/react-overlays/pull/111) but it needed docs… and was closed due to the lack of said docs.